### PR TITLE
Add Quest Proxy

### DIFF
--- a/contracts/LootCreator.sol
+++ b/contracts/LootCreator.sol
@@ -86,6 +86,8 @@ contract LootCreator is Owner, ReentrancyGuard, ILootCreator {
 
     /** @notice Quest Distributors allowed to intract with this contract */
     mapping(address => bool) public allowedDistributors;
+    /** @notice QuestBoard for each Distributor */
+    mapping(address => address) public distributorsBoards;
     /** @notice List of listed Quest Distributors */
     address[] public distributors;
 
@@ -413,8 +415,7 @@ contract LootCreator is Owner, ReentrancyGuard, ILootCreator {
         uint256 questId,
         address distributor
     ) internal view returns(address) {
-        address board = MultiMerkleDistributorV2(distributor).questBoard();
-        return IQuestBoard(board).quests(questId).gauge;
+        return IQuestBoard(distributorsBoards[distributor]).quests(questId).gauge;
     }
 
     function _formatRewardAmount(address token, uint256 amount) internal view returns(uint256) {
@@ -439,8 +440,7 @@ contract LootCreator is Owner, ReentrancyGuard, ILootCreator {
         address distributor,
         uint256 period
     ) internal view returns(Allocation memory) {
-        address board = MultiMerkleDistributorV2(distributor).questBoard();
-        uint256 nbQuestForGauge = IQuestBoard(board).getQuestIdsForPeriodForGauge(gauge, period).length;
+        uint256 nbQuestForGauge = IQuestBoard(distributorsBoards[distributor]).getQuestIdsForPeriodForGauge(gauge, period).length;
         uint256 questTotalRewards = totalQuestPeriodRewards[distributor][questId][period];
         questTotalRewards = _formatRewardAmount(MultiMerkleDistributorV2(distributor).questRewardToken(questId), questTotalRewards);
 
@@ -558,12 +558,13 @@ contract LootCreator is Owner, ReentrancyGuard, ILootCreator {
     * @dev Adds a new Distributor allowed to interact with this contract
     * @param distributor Address of the Distributor
     */
-    function addDistributor(address distributor) external onlyOwner {
-        if(distributor == address(0)) revert Errors.AddressZero();
+    function addDistributor(address distributor, address board) external onlyOwner {
+        if(distributor == address(0) || board == address(0)) revert Errors.AddressZero();
         if(allowedDistributors[distributor]) revert Errors.AlreadyListed();
 
         allowedDistributors[distributor] = true;
         distributors.push(distributor);
+        distributorsBoards[distributor] = board;
 
         emit NewDistributorListed(distributor);
     }
@@ -578,6 +579,7 @@ contract LootCreator is Owner, ReentrancyGuard, ILootCreator {
         if(!allowedDistributors[distributor]) revert Errors.NotListed();
 
         allowedDistributors[distributor] = false;
+        delete distributorsBoards[distributor];
 
         uint256 length = distributors.length;
         for(uint256 i; i < length;){

--- a/contracts/peripheral/QuestBoardProxy.sol
+++ b/contracts/peripheral/QuestBoardProxy.sol
@@ -1,0 +1,87 @@
+//██████╗  █████╗ ██╗      █████╗ ██████╗ ██╗███╗   ██╗
+//██╔══██╗██╔══██╗██║     ██╔══██╗██╔══██╗██║████╗  ██║
+//██████╔╝███████║██║     ███████║██║  ██║██║██╔██╗ ██║
+//██╔═══╝ ██╔══██║██║     ██╔══██║██║  ██║██║██║╚██╗██║
+//██║     ██║  ██║███████╗██║  ██║██████╔╝██║██║ ╚████║
+//╚═╝     ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═════╝ ╚═╝╚═╝  ╚═══╝
+ 
+
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.20;
+
+import {IQuestBoard} from "../interfaces/IQuestBoard.sol";
+import "../libraries/Errors.sol";
+import "../utils/Owner.sol";
+
+/** @title Quest Board Proxy contract */
+/// @author Paladin
+/*
+    Proxy contract for calls from the Loot Creator contract to the Quest Board
+    to handle cases where mutliple active Boards support the same veToken ecosystem
+*/
+contract QuestBoardProxy is Owner {
+
+    address public mainBoard;
+
+    address[] public otherBoards;
+    mapping(address => bool) public isOtherBoard;
+
+    constructor(address _mainBoard, address[] memory _otherBoards){
+        if(_mainBoard == address(0)) revert Errors.AddressZero();
+        mainBoard = _mainBoard;
+        uint256 length = _otherBoards.length;
+        for(uint256 i; i < length; i++){
+            _addOtherBoard(_otherBoards[i]);
+        }
+    }
+
+    /* 
+        This method is only called to receive the length of Quests for the period
+        (to get hte number of Quests for that period on a specific gauge)
+        so we can return an empty array of the length reflecting the number of quests 
+        on the given gauge for the given period
+    */
+    function getQuestIdsForPeriodForGauge(address gauge, uint256 period) external view returns(uint256[] memory) {
+        uint256 questsCount = IQuestBoard(mainBoard).getQuestIdsForPeriodForGauge(gauge, period).length;
+        uint256 boardLength = otherBoards.length;
+        for(uint256 i; i < boardLength; i++){
+            questsCount += IQuestBoard(otherBoards[i]).getQuestIdsForPeriodForGauge(gauge, period).length;
+        }
+        uint256[] memory questIds = new uint256[](questsCount);
+        return questIds;
+    }
+
+	function quests(uint256 id) external view returns(IQuestBoard.Quest memory) {
+        return IQuestBoard(mainBoard).quests(id);
+    }
+
+    function getAllOtherBoard() external view returns(address[] memory){
+        return otherBoards;
+    }
+
+    function _addOtherBoard(address newBoard) internal {
+        if(newBoard == address(0)) revert Errors.AddressZero();
+        if(isOtherBoard[newBoard] || newBoard == mainBoard) revert Errors.AlreadyListed();
+        otherBoards.push(newBoard);
+        isOtherBoard[newBoard] = true;
+    }
+
+    function addOtherBoard(address newBoard) external onlyOwner {
+        _addOtherBoard(newBoard);
+    }
+
+    function removeOtherBoard(address board) external onlyOwner {
+        if(board == address(0)) revert Errors.AddressZero();
+        if(!isOtherBoard[board] || board == mainBoard) revert Errors.NotListed();
+        isOtherBoard[board] = false;
+        uint256 length = otherBoards.length;
+        for(uint256 i; i < length; i++){
+            if(otherBoards[i] == board){
+                otherBoards[i] = otherBoards[length - 1];
+                otherBoards.pop();
+                break;
+            }
+        }
+    }
+
+}

--- a/contracts/test/MockQuestBoard.sol
+++ b/contracts/test/MockQuestBoard.sol
@@ -51,6 +51,22 @@ contract MockQuestBoard {
         );
     }
 
+    function addCustomQuest(uint256 id, address gauge, address creator) external {
+        quests[id] = Quest(
+            creator,
+            address(0),
+            gauge,
+            0,
+            0,
+            0,
+            QuestTypes(
+                QuestDataTypes.QuestVoteType.NORMAL,
+                QuestDataTypes.QuestRewardsType.FIXED,
+                QuestDataTypes.QuestCloseType.NORMAL
+            )
+        );
+    }
+
     function addQuestIdForGaugePerPeriod(uint256 period, address gauge, uint256[] calldata ids) external {
         questIdsForGaugePerPeriod[period][gauge] = ids;
     }

--- a/scripts/test/setup.ts
+++ b/scripts/test/setup.ts
@@ -75,13 +75,13 @@ async function main() {
     await tx.wait(10)
 
     console.log("Set Distribs in Creator")
-    tx = await creator.connect(deployer).addDistributor(distributor_crv.address)
+    tx = await creator.connect(deployer).addDistributor(distributor_crv.address, board_crv_address)
     await tx.wait(10)
-    tx = await creator.connect(deployer).addDistributor(distributor_bal.address)
+    tx = await creator.connect(deployer).addDistributor(distributor_bal.address, board_bal_address)
     await tx.wait(10)
-    tx = await creator.connect(deployer).addDistributor(distributor_lit.address)
+    tx = await creator.connect(deployer).addDistributor(distributor_lit.address, board_lit_address)
     await tx.wait(10)
-    tx = await creator.connect(deployer).addDistributor(distributor_fxn.address)
+    tx = await creator.connect(deployer).addDistributor(distributor_fxn.address, board_fxn_address)
     await tx.wait(10)
 
     const PAL_amount = ethers.utils.parseEther("1000000")

--- a/test/boardProxy.test.ts
+++ b/test/boardProxy.test.ts
@@ -1,0 +1,296 @@
+import { ethers, waffle } from "hardhat";
+import chai from "chai";
+import { solidity } from "ethereum-waffle";
+import { QuestBoardProxy } from "../typechain/contracts/peripheral/QuestBoardProxy";
+import { MockQuestBoard } from "../typechain/contracts/test/MockQuestBoard";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { ContractFactory } from "@ethersproject/contracts";
+import { BigNumber } from "@ethersproject/bignumber";
+import { parseBalanceMap } from "./utils/merkle/parse-balance-map";
+import BalanceTree from "./utils/merkle/balance-tree";
+
+import {
+    resetFork
+} from "./utils/utils";
+
+import {
+    BLOCK_NUMBER
+} from "./integration-tests/constant";
+
+chai.use(solidity);
+const { expect } = chai;
+const { provider } = ethers;
+
+let proxyFactory: ContractFactory
+let boardFactory: ContractFactory
+
+describe('QuestBoardProxy tests', () => {
+    let admin: SignerWithAddress
+
+    let proxy: QuestBoardProxy
+
+    let gauge: SignerWithAddress
+
+    let board1: MockQuestBoard
+    let board2: MockQuestBoard
+    let board3: MockQuestBoard
+    let board4: MockQuestBoard
+
+    let creator1: SignerWithAddress
+    let creator2: SignerWithAddress
+
+    before(async () => {
+        await resetFork(BLOCK_NUMBER);
+
+        [admin, gauge, creator1, creator2] = await ethers.getSigners();
+
+        proxyFactory = await ethers.getContractFactory("QuestBoardProxy");
+        boardFactory = await ethers.getContractFactory("MockQuestBoard");
+
+    })
+
+    beforeEach(async () => {
+
+        board1 = (await boardFactory.deploy()) as MockQuestBoard;
+        await board1.deployed()
+
+        board2 = (await boardFactory.deploy()) as MockQuestBoard;
+        await board2.deployed()
+
+        board3 = (await boardFactory.deploy()) as MockQuestBoard;
+        await board3.deployed()
+
+        board4 = (await boardFactory.deploy()) as MockQuestBoard;
+        await board4.deployed()
+
+        proxy = (await proxyFactory.connect(admin).deploy(
+            board1.address,
+            [board2.address]
+        )) as QuestBoardProxy
+        await proxy.deployed()
+
+    });
+
+    it(' should be deployed correctly', async () => {
+        expect(proxy.address).to.properAddress
+
+        expect(await proxy.mainBoard()).to.be.eq(board1.address)
+        expect(await proxy.otherBoards(0)).to.be.eq(board2.address)
+
+        expect(await proxy.isOtherBoard(board1.address)).to.be.eq(false)
+        expect(await proxy.isOtherBoard(board2.address)).to.be.eq(true)
+        expect(await proxy.isOtherBoard(board3.address)).to.be.eq(false)
+        expect(await proxy.isOtherBoard(board4.address)).to.be.eq(false)
+
+        const other_boards = await proxy.getAllOtherBoard()
+        expect(other_boards).not.to.include(board1.address)
+        expect(other_boards).to.include(board2.address)
+        expect(other_boards).not.to.include(board3.address)
+        expect(other_boards).not.to.include(board4.address)
+        expect(other_boards.length).to.be.eq(1)
+
+    });
+
+    describe('addOtherBoard', async () => {
+
+        it(' should add a new Board correctly', async () => {
+
+            expect(await proxy.isOtherBoard(board3.address)).to.be.eq(false)
+            const other_boards = await proxy.getAllOtherBoard()
+            expect(other_boards).not.to.include(board1.address)
+            expect(other_boards).to.include(board2.address)
+            expect(other_boards).not.to.include(board3.address)
+            expect(other_boards).not.to.include(board4.address)
+            expect(other_boards.length).to.be.eq(1)
+
+            const tx = await proxy.connect(admin).addOtherBoard(board3.address)
+
+            expect(await proxy.isOtherBoard(board3.address)).to.be.eq(true)
+            expect(await proxy.otherBoards(0)).to.be.eq(board2.address)
+            expect(await proxy.otherBoards(1)).to.be.eq(board3.address)
+            const new_other_boards = await proxy.getAllOtherBoard()
+            expect(new_other_boards).not.to.include(board1.address)
+            expect(new_other_boards).to.include(board2.address)
+            expect(new_other_boards).to.include(board3.address)
+            expect(new_other_boards).not.to.include(board4.address)
+            expect(new_other_boards.length).to.be.eq(2)
+
+        });
+
+        it(' should fail if given address 0x0', async () => {
+
+            await expect(
+                proxy.connect(admin).addOtherBoard(ethers.constants.AddressZero)
+            ).to.be.revertedWith("AddressZero")
+
+        });
+
+        it(' should fail if board is already listed', async () => {
+
+            await expect(
+                proxy.connect(admin).addOtherBoard(board2.address)
+            ).to.be.revertedWith("AlreadyListed")
+
+        });
+
+        it(' should fail if board is main board', async () => {
+
+            await expect(
+                proxy.connect(admin).addOtherBoard(board1.address)
+            ).to.be.revertedWith("AlreadyListed")
+
+        });
+
+        it(' should fail if caller not admin', async () => {
+
+            await expect(
+                proxy.connect(gauge).addOtherBoard(board3.address)
+            ).to.be.reverted
+
+        });
+
+    });
+
+    describe('removeOtherBoard', async () => {
+
+        beforeEach(async () => {
+
+            await proxy.connect(admin).addOtherBoard(board3.address)
+
+        });
+
+        it(' should remove the board correctly', async () => {
+
+            expect(await proxy.isOtherBoard(board2.address)).to.be.eq(true)
+            expect(await proxy.isOtherBoard(board3.address)).to.be.eq(true)
+            const other_boards = await proxy.getAllOtherBoard()
+            expect(other_boards).not.to.include(board1.address)
+            expect(other_boards).to.include(board2.address)
+            expect(other_boards).to.include(board3.address)
+            expect(other_boards).not.to.include(board4.address)
+            expect(other_boards.length).to.be.eq(2)
+
+            await proxy.connect(admin).removeOtherBoard(board2.address)
+
+            expect(await proxy.isOtherBoard(board2.address)).to.be.eq(false)
+            expect(await proxy.isOtherBoard(board3.address)).to.be.eq(true)
+            const new_other_boards = await proxy.getAllOtherBoard()
+            expect(new_other_boards).not.to.include(board1.address)
+            expect(new_other_boards).not.to.include(board2.address)
+            expect(new_other_boards).to.include(board3.address)
+            expect(new_other_boards).not.to.include(board4.address)
+            expect(new_other_boards.length).to.be.eq(1)
+
+        });
+
+        it(' should fail if board is not listed', async () => {
+
+            await expect(
+                proxy.connect(admin).removeOtherBoard(board4.address)
+            ).to.be.revertedWith("NotListed")
+
+            await expect(
+                proxy.connect(admin).removeOtherBoard(board1.address)
+            ).to.be.revertedWith("NotListed")
+
+        });
+
+        it(' should fail if given address 0x0', async () => {
+
+            await expect(
+                proxy.connect(admin).removeOtherBoard(ethers.constants.AddressZero)
+            ).to.be.revertedWith("AddressZero")
+
+        });
+
+        it(' should fail if caller not admin', async () => {
+
+            await expect(
+                proxy.connect(gauge).removeOtherBoard(board2.address)
+            ).to.be.reverted
+
+        });
+
+    });
+
+    describe('quests', async () => {
+
+        it(' should return the correct Quest id', async () => {
+
+            await board1.connect(admin).addCustomQuest(1, gauge.address, creator1.address)
+            await board1.connect(admin).addCustomQuest(2, gauge.address, creator1.address)
+            await board2.connect(admin).addCustomQuest(1, gauge.address, creator2.address)
+
+            const quest_data = await proxy.quests(1)
+
+            expect(quest_data.gauge).to.be.eq(gauge.address)
+            expect(quest_data.creator).to.be.eq(creator1.address)
+            expect(quest_data.creator).not.to.be.eq(creator2.address)
+
+        });
+
+    });
+
+    describe('getQuestIdsForPeriodForGauge', async () => {
+
+        let period = 15000
+
+        it(' should return the correct array size - 2 Boards', async () => {
+
+            await board1.connect(admin).addQuestIdForGaugePerPeriod(period, gauge.address, [1,2,3])
+            await board2.connect(admin).addQuestIdForGaugePerPeriod(period, gauge.address, [1,4])
+
+            const all_quests = await proxy.getQuestIdsForPeriodForGauge(gauge.address, period)
+
+            expect(all_quests.length).to.be.eq(5)
+
+        });
+
+        it(' should return the correct array size - 3 Boards', async () => {
+
+            await proxy.connect(admin).addOtherBoard(board3.address)
+            await board1.connect(admin).addQuestIdForGaugePerPeriod(period, gauge.address, [1,2,3])
+            await board2.connect(admin).addQuestIdForGaugePerPeriod(period, gauge.address, [1,4])
+            await board3.connect(admin).addQuestIdForGaugePerPeriod(period, gauge.address, [5,7,8])
+
+            const all_quests = await proxy.getQuestIdsForPeriodForGauge(gauge.address, period)
+
+            expect(all_quests.length).to.be.eq(8)
+
+        });
+
+        it(' should an empty array if nothing in this period', async () => {
+
+            const all_quests = await proxy.getQuestIdsForPeriodForGauge(gauge.address, period)
+
+            expect(all_quests.length).to.be.eq(0)
+
+        });
+
+        it(' should skip if a board has no Quest for this period', async () => {
+
+            await proxy.connect(admin).addOtherBoard(board3.address)
+            await board1.connect(admin).addQuestIdForGaugePerPeriod(period, gauge.address, [1,2,3])
+            await board3.connect(admin).addQuestIdForGaugePerPeriod(period, gauge.address, [5,7,8])
+
+            const all_quests = await proxy.getQuestIdsForPeriodForGauge(gauge.address, period)
+
+            expect(all_quests.length).to.be.eq(6)
+
+        });
+
+        it(' should not account for a board not listed', async () => {
+
+            await board1.connect(admin).addQuestIdForGaugePerPeriod(period, gauge.address, [1,2,3])
+            await board2.connect(admin).addQuestIdForGaugePerPeriod(period, gauge.address, [1,4])
+            await board3.connect(admin).addQuestIdForGaugePerPeriod(period, gauge.address, [5,7,8])
+
+            const all_quests = await proxy.getQuestIdsForPeriodForGauge(gauge.address, period)
+
+            expect(all_quests.length).to.be.eq(5)
+
+        });
+
+    });
+
+});

--- a/test/integration-tests/loot.test.ts
+++ b/test/integration-tests/loot.test.ts
@@ -331,8 +331,8 @@ describe('Loot - Voting & Loot creation tests', () => {
                 ethers.utils.parseEther("0.5")
             )
 
-            await creator.connect(admin).addDistributor(distributor1.address)
-            await creator.connect(admin).addDistributor(distributor2.address)
+            await creator.connect(admin).addDistributor(distributor1.address, board1.address)
+            await creator.connect(admin).addDistributor(distributor2.address, board2.address)
 
             await budget.connect(admin).updatePalWeeklyBudget(pal_budget)
             await budget.connect(admin).updateExtraWeeklyBudget(extra_budget)

--- a/test/integration-tests/loot_with_boost.test.ts
+++ b/test/integration-tests/loot_with_boost.test.ts
@@ -331,8 +331,8 @@ describe('Loot - Voting & Loot creation tests - with delegated boost', () => {
                 ethers.utils.parseEther("0.5")
             )
 
-            await creator.connect(admin).addDistributor(distributor1.address)
-            await creator.connect(admin).addDistributor(distributor2.address)
+            await creator.connect(admin).addDistributor(distributor1.address, board1.address)
+            await creator.connect(admin).addDistributor(distributor2.address, board2.address)
 
             await budget.connect(admin).updatePalWeeklyBudget(pal_budget)
             await budget.connect(admin).updateExtraWeeklyBudget(extra_budget)


### PR DESCRIPTION
Quest Board Proxy allowing to handle multiple Boards on same veTokens that would have Quests on the same gauge at the same period